### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
`.env` should be added to the gitgnore as it is [supported by Next.js](https://nextjs.org/docs/basic-features/environment-variables#default-environment-variables).

As it is currently missing, someone might accidentally commit their `.env` file with secrets in it.