### PR TITLE
change getInitialProps in _app to enable getInitialProps in other page components

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,11 @@
-import { GetServerSidePropsContext } from 'next';
 import { useState } from 'react';
-import { AppProps } from 'next/app';
+import App, { AppContext, AppProps } from 'next/app';
 import { getCookie, setCookie } from 'cookies-next';
 import Head from 'next/head';
 import { MantineProvider, ColorScheme, ColorSchemeProvider } from '@mantine/core';
 import { NotificationsProvider } from '@mantine/notifications';
 
-export default function App(props: AppProps & { colorScheme: ColorScheme }) {
+export default function MyApp(props: AppProps & { colorScheme: ColorScheme }) {
   const { Component, pageProps } = props;
   const [colorScheme, setColorScheme] = useState<ColorScheme>(props.colorScheme);
 
@@ -35,6 +34,11 @@ export default function App(props: AppProps & { colorScheme: ColorScheme }) {
   );
 }
 
-App.getInitialProps = ({ ctx }: { ctx: GetServerSidePropsContext }) => ({
-  colorScheme: getCookie('mantine-color-scheme', ctx) || 'light',
-});
+MyApp.getInitialProps = async (appContext: AppContext) => {
+  const { ctx } = appContext;
+  const appProps = await App.getInitialProps(appContext);
+  return {
+    ...appProps,
+    colorScheme: getCookie('mantine-color-scheme', ctx) || 'light',
+  };
+};


### PR DESCRIPTION
I've made a change to how `getInitialProps` gets implemented in the `_app` component. This is to enable `getInitialProps` to be used in other pages as otherwise props always turn up as undefined. 

These changes are as per the nextjs docs here: https://nextjs.org/docs/advanced-features/custom-app